### PR TITLE
Fixes bug caused by unescaped brackets

### DIFF
--- a/gallery.html
+++ b/gallery.html
@@ -376,7 +376,7 @@ function loadImage(url) {
     }
   };
   imageLoader.src = url;
-  document.getElementById("loadingimage").setAttribute("style","background-image:url("+url+")");
+  document.getElementById("loadingimage").setAttribute("style","background-image:url("+url.replace(/\(/g, "\\(").replace(/\)/g, "\\)")+")");
   showingImage = url;
 }
 


### PR DESCRIPTION
When filenames contain a bracket, it interferes with the brackets in the background-image css. The bug stops the main image from being loaded, leaving only the low resolution preview on screen. This commit escapes brackets in the filename.