### PR TITLE
Added darkhttpd compatibility.

### DIFF
--- a/gallery.html
+++ b/gallery.html
@@ -1,3 +1,4 @@
+<meta charset="UTF-8"> 
 <html>
 <!--
 
@@ -336,7 +337,7 @@ function addDeferredThumb(thumbs, href) {
 }
 
 function addFolder(thumbs, href) {
-  var niceName = href.substr(0,href.length-1);
+  var niceName = href; //href.substr(0,href.length-1);
   if (niceName.lastIndexOf("/")>=0)
     niceName = niceName.substr(niceName.lastIndexOf("/")+1);
   if (href.length < baseURL.length) niceName = "[BACK]";
@@ -354,8 +355,12 @@ function processIndexPage() {
   var handled = [];
   for (var i=0;i<elements.length;i++) {
     var href = elements[i].href;
+    var text = elements[i].innerText;
+    var parentText = elements[i].parentElement.innerText;
+    var re = new RegExp(text + '\/', "g");
+
     if (handled.indexOf(href)>=0) continue;
-    if (href[href.length-1]=="/" && href!==baseURL) {
+    if ((href[href.length-1]=="/" || parentText.match(re) )&& href!==baseURL) {
       handled.push(href);
       addFolder(thumbs, href);
     }


### PR DESCRIPTION
The gallery had an issue on darkhttpd.
In index.html, trailing '/'s are not outputted **inside** the `<a>` elements, neither in their `href` attribute, but in the parent `<pre>` element. 

The `processIndexPage()` is now looking for directories by matching for '/' characters inside and outside  `<a>` elements.

I also had to edit the `addFolder` function because the last character of the folder name was not shown.
The `addFolder()` function now displays the trailing '/' for directories, but i am afraid this breaks compatibility with other webservers.

Could you test on other webservers to see if this commit doesn't break functionality?
